### PR TITLE
index.ts: remove -linux suffix from userAgent

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,7 +56,7 @@ function createMainWindow() {
 			`http://localhost:${process.env.ELECTRON_WEBPACK_WDS_PORT}?version=DEV`
 		);
 	} else {
-		crewlinkVersion = autoUpdater.currentVersion.version;
+		crewlinkVersion = autoUpdater.currentVersion.version.replace(/-linux$/, '');
 		window.loadURL(
 			formatUrl({
 				pathname: joinPath(__dirname, 'index.html'),


### PR DESCRIPTION
The userAgent is taken from the version number. However, when the server
does a version check, it considers the suffix to be a different version
and we get the following error:

	The voice server does not support your version of CrewLink.
	Supported versions: 1.2.0,1.2.1

Remove the -linux suffix when setting the userAgent so that the server
recognizes this as a legitimate version of CrewLink.

Currently, the release process works around this by tagging a commit not
on any branch which modifies the package.json version to remove the
-linux suffix. This change obviates that need.